### PR TITLE
feat: add CodeRabbit AI review configuration and GitHub labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# .coderabbit.yaml
+language: "en-GB"
+
+reviews:
+  profile: "assertive"                 # or "chill"
+  high_level_summary: true
+  commit_status: true                  # adds a status check
+  fail_commit_status: false            # set true to fail when CR can't review
+  changed_files_summary: true
+  estimate_code_review_effort: true
+  path_filters:
+    - "apps/**"
+    - "packages/**"
+    - "!collaboration/logs/**"
+    - "!**/*.lock"
+    - "!**/dist/**"
+  auto_review:
+    enabled: true                      # autorun on PR open/sync
+    auto_incremental_review: true      # re-run on each push
+    drafts: false
+    labels: ["!wip", "!skip-ai-review"]# opt-out label
+
+  finishing_touches:
+    docstrings: { enabled: true }
+    unit_tests: { enabled: false }     # flip on later if you like
+
+  pre_merge_checks:
+    title: { mode: "warning" }
+    docstrings: { mode: "warning", threshold: 60 }
+
+tools:
+  github-checks: { enabled: true }     # surfaces a Check entry
+  ruff: { enabled: true }
+  shellcheck: { enabled: true }
+  markdownlint: { enabled: true }

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,9 @@
+# .github/labels.yml
+# So you can sync labels quickly.
+
+- name: skip-ai-review
+  color: "b60205"
+  description: "Do not run Codex/CodeRabbit on this PR"
+- name: ai-review
+  color: "0e8a16"
+  description: "Force Codex/CodeRabbit to run"


### PR DESCRIPTION
## Summary
- Add CodeRabbit AI review configuration for automated code reviews
- Add GitHub labels for controlling AI review behavior
- Configure assertive review profile with comprehensive analysis

## CodeRabbit Configuration (.coderabbit.yaml)
- **Assertive profile**: Thorough code reviews with detailed feedback
- **Auto-review enabled**: Runs on PR open/sync with incremental reviews
- **Path filters**: Focus on `apps/**` and `packages/**` (exclude logs, locks, dist)  
- **Opt-out labels**: `!wip` and `!skip-ai-review` for control
- **GitHub checks integration**: Includes ruff, shellcheck, markdownlint
- **Finishing touches**: Docstring suggestions enabled
- **Pre-merge warnings**: Title and docstring coverage checks (60% threshold)

## GitHub Labels (.github/labels.yml)
- `skip-ai-review` (red) - Prevents CodeRabbit from running on PRs
- `ai-review` (green) - Forces CodeRabbit to run on PRs

## Benefits
- **Consistent reviews**: AI-powered analysis on every PR
- **Quality gates**: Pre-merge checks for title and documentation  
- **Flexible control**: Opt-out mechanism with labels
- **Tool integration**: Automatic linting and validation
- **Documentation focus**: Encourages good docstring practices

## Test plan
- [ ] Verify CodeRabbit runs on new PRs automatically
- [ ] Test opt-out mechanism with `skip-ai-review` label
- [ ] Confirm GitHub checks integration works
- [ ] Validate path filters exclude unwanted directories

🤖 Generated with [Claude Code](https://claude.ai/code)