### PR TITLE
fix(ci): auth header and lint for validate-api

### DIFF
--- a/.github/workflows/validate-api.yml
+++ b/.github/workflows/validate-api.yml
@@ -1,13 +1,14 @@
+---
 name: Validate API Specification
 
-on:
+'on':
   push:
-    branches: [ main, feat/orchestrator-v1-api ]
+    branches: [main, feat/orchestrator-v1-api]
     paths:
       - 'api-specs/**'
       - 'apps/adk-orchestrator/**'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'api-specs/**'
       - 'apps/adk-orchestrator/**'
@@ -15,91 +16,100 @@ on:
 jobs:
   validate-api:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 15
+
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install fastapi uvicorn pydantic pydantic-settings PyYAML
-        pip install openapi-spec-validator
-    
-    - name: Validate OpenAPI spec
-      run: |
-        python -c "
-        import yaml
-        from openapi_spec_validator import validate_spec
-        
-        # Load and validate the API spec
-        with open('api-specs/orchestrator-v1.yaml', 'r') as f:
-            spec = yaml.safe_load(f)
-        
-        try:
-            validate_spec(spec)
-            print('✅ OpenAPI specification is valid')
-        except Exception as e:
-            print(f'❌ OpenAPI specification validation failed: {e}')
-            exit(1)
-        "
-    
-    - name: Test API endpoints
-      run: |
-        cd apps/adk-orchestrator
-        python -c "
-        import sys
-        sys.path.append('../../packages')
-        
-        from main import app
-        from fastapi.testclient import TestClient
-        
-        client = TestClient(app)
-        
-        # Test health endpoints
-        health_response = client.get('/healthz')
-        assert health_response.status_code == 200
-        assert health_response.json() == {'ok': True}
-        print('✅ /healthz endpoint working')
-        
-        ready_response = client.get('/readyz')
-        assert ready_response.status_code == 200
-        assert ready_response.json() == {'ready': True}
-        print('✅ /readyz endpoint working')
-        
-        # Test config endpoint
-        config_response = client.get('/v1/config')
-        assert config_response.status_code == 200
-        config_data = config_response.json()
-        assert 'services' in config_data
-        assert 'agents' in config_data
-        assert 'log' in config_data
-        print('✅ /v1/config endpoint working')
-        
-        # Test plan endpoint with valid data
-        plan_data = {
-            'pr': {
-                'repo': 'test/repo',
-                'pr_number': 123,
-                'branch': 'feature/test',
-                'head_sha': 'abc123'
-            },
-            'mode': 'plan',
-            'labels': ['test'],
-            'extra': {}
-        }
-        
-        plan_response = client.post('/v1/runs/plan', json=plan_data)
-        assert plan_response.status_code == 200
-        plan_result = plan_response.json()
-        assert 'run_id' in plan_result
-        assert 'status' in plan_result
-        assert 'started_at' in plan_result
-        print('✅ /v1/runs/plan endpoint working')
-        
-        print('🎉 All API endpoints validated successfully!')
-        "
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi uvicorn pydantic pydantic-settings PyYAML
+          pip install openapi-spec-validator
+
+      - name: Validate OpenAPI spec
+        run: |
+          python -c "
+          import yaml
+          from openapi_spec_validator import validate_spec
+
+          # Load and validate the API spec
+          with open('api-specs/orchestrator-v1.yaml', 'r') as f:
+              spec = yaml.safe_load(f)
+
+          try:
+              validate_spec(spec)
+              print('✅ OpenAPI specification is valid')
+          except Exception as e:
+              print(f'❌ OpenAPI specification validation failed: {e}')
+              exit(1)
+          "
+
+      - name: Test API endpoints
+        run: |
+          cd apps/adk-orchestrator
+          python -c "
+          import sys
+          sys.path.append('../../packages')
+
+          from main import app
+          from fastapi.testclient import TestClient
+          from security.jwt import create_dev_token
+
+          client = TestClient(app)
+
+          # Generate dev token for authorization
+          token = create_dev_token(sub='ci', tenant_id='ci')
+          headers = {'Authorization': f'Bearer {token}'}
+
+          # Test health endpoints
+          health_response = client.get('/healthz')
+          assert health_response.status_code == 200
+          assert health_response.json() == {'ok': True}
+          print('✅ /healthz endpoint working')
+
+          ready_response = client.get('/readyz')
+          assert ready_response.status_code == 200
+          assert ready_response.json() == {'ready': True}
+          print('✅ /readyz endpoint working')
+
+          # Test config endpoint
+          config_response = client.get('/v1/config')
+          assert config_response.status_code == 200
+          config_data = config_response.json()
+          assert 'services' in config_data
+          assert 'agents' in config_data
+          assert 'log' in config_data
+          print('✅ /v1/config endpoint working')
+
+          # Test plan endpoint with valid data
+          plan_data = {
+              'pr': {
+                  'repo': 'test/repo',
+                  'pr_number': 123,
+                  'branch': 'feature/test',
+                  'head_sha': 'abc123'
+              },
+              'mode': 'plan',
+              'labels': ['test'],
+              'extra': {},
+          }
+
+          plan_response = client.post(
+              '/v1/runs/plan', json=plan_data, headers=headers
+          )
+          assert plan_response.status_code == 200
+          plan_result = plan_response.json()
+          assert 'run_id' in plan_result
+          assert 'status' in plan_result
+          assert 'started_at' in plan_result
+          print('✅ /v1/runs/plan endpoint working')
+
+          print('🎉 All API endpoints validated successfully!')
+          "


### PR DESCRIPTION
## Summary
- supply dev bearer token for `/v1/runs/plan` validation call
- upgrade validate-api workflow to `actions/setup-python@v5`, enable caching and add job timeout
- fix workflow YAML formatting issues

## Testing
- `yamllint .github/workflows/validate-api.yml`
- `/tmp/actionlint .github/workflows/validate-api.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bcfe78c5708321a8cff233e81b6b93