### PR TITLE
fix(ci): install PyJWT for validate-api workflow

### DIFF
--- a/.github/workflows/validate-api.yml
+++ b/.github/workflows/validate-api.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn pydantic pydantic-settings PyYAML
+          pip install fastapi uvicorn pydantic pydantic-settings PyYAML PyJWT
           pip install openapi-spec-validator
 
       - name: Validate OpenAPI spec


### PR DESCRIPTION
## Summary
- install PyJWT to enable dev token generation in validate-api workflow

## Testing
- `yamllint .github/workflows/validate-api.yml`
- `/tmp/actionlint .github/workflows/validate-api.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd09b16c748321871e436703a40265