### PR TITLE
fix(console): add root layout for App Router

### DIFF
--- a/apps/console/app/globals.css
+++ b/apps/console/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Kyros Console",
+  description: "Kyros agent console",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/console/next.config.js
+++ b/apps/console/next.config.js
@@ -1,1 +1,1 @@
-module.exports = { reactStrictMode: true, experimental: { appDir: true } };
+module.exports = { reactStrictMode: true };


### PR DESCRIPTION
## Summary
- add root layout and global stylesheet for the console App Router
- remove deprecated experimental.appDir flag from Next.js config

## Testing
- `npm run build` *(fails: Your custom PostCSS configuration must export a `plugins` key)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0b44e69883219aeeaaff9824c3c6