### PR TITLE
fix(ci): remove merge conflict artifacts from contract.yml

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -35,7 +35,6 @@ import datetime, jwt
 token = jwt.encode({'sub': 'dev', 'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=5)}, 'dev-secret', algorithm='HS256')
 print(f'DEV_JWT={token}')
 PY
->>>>>>> origin/main
       - name: Schemathesis against /v1
         run: |
           schemathesis run api-specs/orchestrator-v1.yaml --base-url http://127.0.0.1:8080 \


### PR DESCRIPTION
## Summary
Fixes CI failures on main branch by removing merge conflict artifacts that were inadvertently left in the contract.yml workflow file.

## Problem
The main branch CI was failing because contract.yml contained a stray `>>>>>>> origin/main` line from an incomplete merge resolution, causing YAML syntax errors.

## Solution
- Remove the merge conflict artifact from line 38 in contract.yml
- Workflow should now parse correctly and run properly

## Testing
This should fix the failing contract, e2e, and validate-api workflows on main branch.

🤖 Generated with [Claude Code](https://claude.ai/code)