### PR TITLE
fix(ci): correct uvicorn startup in validate-api.yml

### DIFF
--- a/.github/workflows/validate-api.yml
+++ b/.github/workflows/validate-api.yml
@@ -37,7 +37,7 @@ print(f'DEV_JWT={token}')
 PY
       - name: Start orchestrator
         run: |
-          uvicorn apps/adk-orchestrator.main:app --host 127.0.0.1 --port 8080 &
+          cd apps/adk-orchestrator && uvicorn main:app --host 127.0.0.1 --port 8080 &
           echo $! > uvicorn.pid
           for i in {1..30}; do
             if curl -fsS http://127.0.0.1:8080/healthz >/dev/null; then


### PR DESCRIPTION
## Summary
Fixes the validate-api.yml workflow by correcting the uvicorn startup pattern to match other workflows.

## Problem
The validate-api.yml workflow was using the broken pattern:
```
uvicorn apps/adk-orchestrator.main:app
```

This causes `ModuleNotFoundError: No module named 'apps/adk-orchestrator'` due to Python import path issues with hyphenated directory names.

## Solution  
Changed to the correct pattern used in contract.yml and e2e.yml:
```
cd apps/adk-orchestrator && uvicorn main:app
```

This matches the pattern from the handover context and should resolve the module import issues.

## Testing
Should fix the failing validate-api workflow on main branch.

🤖 Generated with [Claude Code](https://claude.ai/code)